### PR TITLE
Add process(source) option to control generation of `template`, `script`, and `style` content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,28 @@ preProcess: function(source) {
 }
 ```
 
+### process
+
+Function. For example
+```javascript
+// This is useful when used with front-matter-loader to set the page title in nuxt projects
+process: function(source){
+  let attrs = (source && source.attributes) || {}
+  attrs.title = attrs.title || ""
+  return {
+    template: source.body,
+    style: "",
+    script: `export default {
+      head(){
+        return {
+          title: '${attrs.title}'
+        }
+      }
+    }`
+  }
+}
+```
+
 ### afterProcess
 
 Function. For example:

--- a/src/parser.js
+++ b/src/parser.js
@@ -44,6 +44,7 @@ function Parser (_options) {
     plugins: [], // Markdown-It plugins
     wrapper: 'section', // content wrapper
     preProcess: null,
+    process: null,
     afterProcess: null
   }
   // merge user options into defaults
@@ -219,7 +220,14 @@ Parser.prototype.parse = function (source) {
   if (this.options.preProcess && typeof this.options.preProcess === 'function') {
     this.source = this.options.preProcess(this.source)
   }
-  let result = this.options.live ? this.parseLives() : {template: source, script: '', style: ''}
+  let result
+  if (this.options.process && typeof this.options.process === 'function') {
+    result = this.options.process(this.source)
+    result.script = `<script>${result.script || ''}</script>`
+    result.style = `<style>${result.style || ''}</style>`
+  } else {
+    result = this.options.live ? this.parseLives() : {template: this.source, script: '', style: ''}
+  }
   let html = this.markdown.render(result.template)
   let vueFile = `<template><${this.options.wrapper}>${html}</${this.options.wrapper}></template>${result.style}${result.script}`
   if (this.options.afterProcess && typeof this.options.afterProcess === 'function') {


### PR DESCRIPTION
Add `process(source)` option becauseI needed a way to control how the component is defined in the <script> tag. In my use case, I need to process output from [front-matter-loader](https://github.com/elliottsj/front-matter-loader)  and pass the front matter attributes such as page title to the component as required by Nuxt.

I've added documentation for how the `process` option can be used to README.md

If the `process` option is not provided, it will fallback to the existing implementation. 

I can add documentation on how to chain this `front-matter-loader` in the future.